### PR TITLE
maintain shape consistency for 1D arrays

### DIFF
--- a/angler/derivatives.py
+++ b/angler/derivatives.py
@@ -1,10 +1,9 @@
-import numpy as np
 import scipy.sparse as sp
 
 from angler.constants import DEFAULT_MATRIX_FORMAT
 
 
-def createDws(w, s, dL, N, matrix_format=DEFAULT_MATRIX_FORMAT):
+def createDws(w, s, dL, N, matrix_format = DEFAULT_MATRIX_FORMAT, use_dirichlet_bcs = False):
     # creates the derivative matrices
     # NOTE: python uses C ordering rather than Fortran ordering. Therefore the
     # derivative operators are constructed slightly differently than in MATLAB
@@ -20,21 +19,33 @@ def createDws(w, s, dL, N, matrix_format=DEFAULT_MATRIX_FORMAT):
     if w is 'x':
         if Nx > 1:
             if s is 'f':
-                dxf = sp.diags([-1, 1, 1], [0, 1, -Nx+1], shape=(Nx, Nx))
-                Dws = 1/dx*sp.kron(dxf, sp.eye(Ny), format=matrix_format)
+                if use_dirichlet_bcs:
+                    dxf = sp.diags([-1, 1], [0, 1], shape = (Nx, Nx))
+                else:
+                    dxf = sp.diags([-1, 1, 1], [0, 1, -Nx + 1], shape = (Nx, Nx))
+                Dws = 1 / dx * sp.kron(dxf, sp.eye(Ny), format = matrix_format)
             else:
-                dxb = sp.diags([1, -1, -1], [0, -1, Nx-1], shape=(Nx, Nx))
-                Dws = 1/dx*sp.kron(dxb, sp.eye(Ny), format=matrix_format)
+                if use_dirichlet_bcs:
+                    dxb = sp.diags([1, -1], [0, 1], shape = (Nx, Nx))
+                else:
+                    dxb = sp.diags([1, -1, -1], [0, -1, Nx - 1], shape = (Nx, Nx))
+                Dws = 1 / dx * sp.kron(dxb, sp.eye(Ny), format = matrix_format)
         else:
-            Dws = sp.eye(Ny)            
+            Dws = sp.eye(Ny)
     if w is 'y':
         if Ny > 1:
             if s is 'f':
-                dyf = sp.diags([-1, 1, 1], [0, 1, -Ny+1], shape=(Ny, Ny))
-                Dws = 1/dy*sp.kron(sp.eye(Nx), dyf, format=matrix_format)
+                if use_dirichlet_bcs:
+                    dyf = sp.diags([-1, 1], [0, 1], shape = (Ny, Ny))
+                else:
+                    dyf = sp.diags([-1, 1, 1], [0, 1, -Ny + 1], shape = (Ny, Ny))
+                Dws = 1 / dy * sp.kron(sp.eye(Nx), dyf, format = matrix_format)
             else:
-                dyb = sp.diags([1, -1, -1], [0, -1, Ny-1], shape=(Ny, Ny))
-                Dws = 1/dy*sp.kron(sp.eye(Nx), dyb, format=matrix_format)
+                if use_dirichlet_bcs:
+                    dyb = sp.diags([1, -1], [0, -1], shape = (Ny, Ny))
+                else:
+                    dyb = sp.diags([1, -1, -1], [0, -1, Ny - 1], shape = (Ny, Ny))
+                Dws = 1 / dy * sp.kron(sp.eye(Nx), dyb, format = matrix_format)
         else:
             Dws = sp.eye(Nx)
     return Dws
@@ -47,4 +58,4 @@ def unpack_derivs(derivs):
     Dxb = derivs['Dxb']
     Dxf = derivs['Dxf']
     Dyf = derivs['Dyf']
-    return (Dyb, Dxb, Dxf, Dyf)
+    return Dyb, Dxb, Dxf, Dyf

--- a/angler/derivatives.py
+++ b/angler/derivatives.py
@@ -26,7 +26,7 @@ def createDws(w, s, dL, N, matrix_format = DEFAULT_MATRIX_FORMAT, use_dirichlet_
                 Dws = 1 / dx * sp.kron(dxf, sp.eye(Ny), format = matrix_format)
             else:
                 if use_dirichlet_bcs:
-                    dxb = sp.diags([1, -1], [0, 1], shape = (Nx, Nx))
+                    dxb = sp.diags([1, -1], [0, -1], shape = (Nx, Nx))
                 else:
                     dxb = sp.diags([1, -1, -1], [0, -1, Nx - 1], shape = (Nx, Nx))
                 Dws = 1 / dx * sp.kron(dxb, sp.eye(Ny), format = matrix_format)

--- a/angler/linalg.py
+++ b/angler/linalg.py
@@ -44,6 +44,7 @@ def is_equal(matrix1, matrix2):
 
 def construct_A(omega, xrange, yrange, eps_r, NPML, pol, L0,
                 averaging=True,
+                use_dirichlet_bcs=False,
                 timing=False,
                 matrix_format=DEFAULT_MATRIX_FORMAT):
     # makes the A matrix
@@ -60,10 +61,10 @@ def construct_A(omega, xrange, yrange, eps_r, NPML, pol, L0,
         (Sxf, Sxb, Syf, Syb) = S_create(omega, L0, N, NPML, xrange, yrange, matrix_format=matrix_format)
 
         # Construct derivate matrices
-        Dyb = Syb.dot(createDws('y', 'b', dL(N, xrange, yrange), N, matrix_format=matrix_format))
-        Dxb = Sxb.dot(createDws('x', 'b', dL(N, xrange, yrange), N, matrix_format=matrix_format))
-        Dxf = Sxf.dot(createDws('x', 'f', dL(N, xrange, yrange), N, matrix_format=matrix_format))
-        Dyf = Syf.dot(createDws('y', 'f', dL(N, xrange, yrange), N, matrix_format=matrix_format))
+        Dyb = Syb.dot(createDws('y', 'b', dL(N, xrange, yrange), N, matrix_format=matrix_format, use_dirichlet_bcs=use_dirichlet_bcs))
+        Dxb = Sxb.dot(createDws('x', 'b', dL(N, xrange, yrange), N, matrix_format=matrix_format, use_dirichlet_bcs=use_dirichlet_bcs))
+        Dxf = Sxf.dot(createDws('x', 'f', dL(N, xrange, yrange), N, matrix_format=matrix_format, use_dirichlet_bcs=use_dirichlet_bcs))
+        Dyf = Syf.dot(createDws('y', 'f', dL(N, xrange, yrange), N, matrix_format=matrix_format, use_dirichlet_bcs=use_dirichlet_bcs))
 
         A = (Dxf*1/MU_0_).dot(Dxb) \
             + (Dyf*1/MU_0_).dot(Dyb) \
@@ -86,10 +87,10 @@ def construct_A(omega, xrange, yrange, eps_r, NPML, pol, L0,
         (Sxf, Sxb, Syf, Syb) = S_create(omega, L0, N, NPML, xrange, yrange, matrix_format=matrix_format)
 
         # Construct derivate matrices
-        Dyb = Syb.dot(createDws('y', 'b', dL(N, xrange, yrange), N, matrix_format=matrix_format))
-        Dxb = Sxb.dot(createDws('x', 'b', dL(N, xrange, yrange), N, matrix_format=matrix_format))
-        Dxf = Sxf.dot(createDws('x', 'f', dL(N, xrange, yrange), N, matrix_format=matrix_format))
-        Dyf = Syf.dot(createDws('y', 'f', dL(N, xrange, yrange), N, matrix_format=matrix_format))
+        Dyb = Syb.dot(createDws('y', 'b', dL(N, xrange, yrange), N, matrix_format=matrix_format, use_dirichlet_bcs=use_dirichlet_bcs))
+        Dxb = Sxb.dot(createDws('x', 'b', dL(N, xrange, yrange), N, matrix_format=matrix_format, use_dirichlet_bcs=use_dirichlet_bcs))
+        Dxf = Sxf.dot(createDws('x', 'f', dL(N, xrange, yrange), N, matrix_format=matrix_format, use_dirichlet_bcs=use_dirichlet_bcs))
+        Dyf = Syf.dot(createDws('y', 'f', dL(N, xrange, yrange), N, matrix_format=matrix_format, use_dirichlet_bcs=use_dirichlet_bcs))
 
         A =   Dxf.dot(T_eps_x_inv).dot(Dxb) \
             + Dyf.dot(T_eps_y_inv).dot(Dyb) \

--- a/angler/simulation.py
+++ b/angler/simulation.py
@@ -14,7 +14,7 @@ from angler.plot import plt_base_eps, plt_base
 
 class Simulation:
 
-    def __init__(self, omega, eps_r, dl, NPML, pol, L0=DEFAULT_LENGTH_SCALE):
+    def __init__(self, omega, eps_r, dl, NPML, pol, L0=DEFAULT_LENGTH_SCALE, use_dirichlet_bcs=False):
         # initializes Fdfd object
 
         self.L0 = L0
@@ -22,6 +22,7 @@ class Simulation:
         self.NPML = NPML
         self.pol = pol
         self.dl = dl
+        self.use_dirichlet_bcs = use_dirichlet_bcs
 
         self._check_inputs()
 
@@ -107,6 +108,7 @@ class Simulation:
         (A, derivs) = construct_A(self.omega, self.xrange, self.yrange,
                                   self.eps_r, self.NPML, self.pol, self.L0,
                                   matrix_format=DEFAULT_MATRIX_FORMAT,
+                                  use_dirichlet_bcs=self.use_dirichlet_bcs,
                                   timing=False)
         self.A = A
         self.derivs = derivs

--- a/angler/simulation.py
+++ b/angler/simulation.py
@@ -27,8 +27,11 @@ class Simulation:
 
         grid_shape = eps_r.shape
         if len(grid_shape) == 1:
+            self.flatten = True
             grid_shape = (grid_shape[0], 1)
             eps_r = np.reshape(eps_r, grid_shape)
+        else:
+            self.flatten = False
 
         (Nx, Ny) = grid_shape
 
@@ -147,9 +150,14 @@ class Simulation:
             ex =  1/1j/self.omega * T_eps_y_inv.dot(Dyb).dot(X)
             ey = -1/1j/self.omega * T_eps_x_inv.dot(Dxb).dot(X)
 
-            Ex = ex.reshape((Nx, Ny))
-            Ey = ey.reshape((Nx, Ny))
-            Hz = X.reshape((Nx, Ny))
+            if self.flatten:
+                Ex = ex.flatten()
+                Ey = ey.flatten()
+                Hz = X.flatten()
+            else:
+                Ex = ex.reshape((Nx, Ny))
+                Ey = ey.reshape((Nx, Ny))
+                Hz = X.reshape((Nx, Ny))
 
             if include_nl==False:
                 self.fields['Ex'] = Ex
@@ -162,9 +170,14 @@ class Simulation:
             hx = -1/1j/self.omega/MU_0_ * Dyb.dot(X)
             hy = 1/1j/self.omega/MU_0_ * Dxb.dot(X)
 
-            Hx = hx.reshape((Nx, Ny))
-            Hy = hy.reshape((Nx, Ny))
-            Ez = X.reshape((Nx, Ny))
+            if self.flatten:
+                Hx = hx.flatten()
+                Hy = hy.flatten()
+                Ez = X.flatten()
+            else:
+                Hx = hx.reshape((Nx, Ny))
+                Hy = hy.reshape((Nx, Ny))
+                Ez = X.reshape((Nx, Ny))
 
             if include_nl==False:
                 self.fields['Hx'] = Hx


### PR DESCRIPTION
Added a `Simulation.flatten` property which is set to true if epsilons is passed in with shape `(N,)`